### PR TITLE
Fix: proper newline for prysm, thanks @jcrpt

### DIFF
--- a/drawer/drawer.go
+++ b/drawer/drawer.go
@@ -280,7 +280,7 @@ func getGraffitiTemplate() string {
 	case "lighthouse":
 		template = `default: %s`
 	case "prysm":
-		template = `ordered:\n  - "%s"`
+		template = `ordered:` + "\n" + `  - "%s"`
 	}
 	return template
 }


### PR DESCRIPTION
Proper newline for prysm, as opposed to a literal \n