### PR TITLE
Updated deprecated Nimbus URL

### DIFF
--- a/drawer/drawer.go
+++ b/drawer/drawer.go
@@ -243,7 +243,7 @@ func updateGraffiti() bool {
 			}
 			// Is it already drawn?
 			if wallCheck[fmt.Sprintf("%s:%s", pixel.X, pixel.Y)] == strings.ToLower(pixel.Color) ||
-			(len(wallCheck[fmt.Sprintf("%s:%s", pixel.X, pixel.Y)]) == 0 && strings.ToLower(pixel.Color) == "ffffff") {
+				(len(wallCheck[fmt.Sprintf("%s:%s", pixel.X, pixel.Y)]) == 0 && strings.ToLower(pixel.Color) == "ffffff") {
 				completed++
 			} else {
 				todoPixels.Data = append(todoPixels.Data, pixel)
@@ -311,8 +311,8 @@ func getGraffiti(pixel DrawerPixel) string {
 }
 
 func setNimbusGraffiti(graffiti string) error {
-	// We send the graffiti data directly to nimbus' api at NIMBUSURL/api/nimbus/v1/graffiti
-	url := fmt.Sprintf("%s%s", strings.TrimSuffix(NimbusURL, "/"), "/api/nimbus/v1/graffiti")
+	// We send the graffiti data directly to nimbus' api at NIMBUSURL/nimbus/v1/graffiti
+	url := fmt.Sprintf("%s%s", strings.TrimSuffix(NimbusURL, "/"), "/nimbus/v1/graffiti")
 	log.Printf("Sending graffiti [%s] to nimbus at %s...\n", graffiti, url)
 
 	// response = requests.post(url, headers=header, data=graffiti)


### PR DESCRIPTION
Nimbus removed the `/api/nimbus...` routes in v22.9.1, which were just redirects towards `/nimbus/...` anyway. This makes the drawer compatible with all versions, including old ones and new ones moving forward.